### PR TITLE
test(response): add response unit tests

### DIFF
--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace Carl\Response;
 
-use Carl\Exception;
-
 use function is_array;
 
 use const JSON_THROW_ON_ERROR;
@@ -51,7 +49,7 @@ final readonly class JsonResponse implements Response
     {
         $data = json_decode($this->origin->body(), true, 512, JSON_THROW_ON_ERROR);
         if (!is_array($data)) {
-            throw new Exception('JSON root is not an object/array');
+            throw new JsonException('JSON root is not an object/array');
         }
 
         return $data;

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -53,7 +53,7 @@ final readonly class JsonResponse implements Response
         if (!is_array($data)) {
             throw new Exception('JSON root is not an object/array');
         }
-        /** @var array<string|int,mixed> $data */
+
         return $data;
     }
 }

--- a/src/Response/ParsedResponse.php
+++ b/src/Response/ParsedResponse.php
@@ -55,6 +55,6 @@ final readonly class ParsedResponse
 
         return $offset === false
             ? $this->raw
-            : substr($this->raw, $offset + strlen($header));
+            : ltrim(substr($this->raw, $offset + strlen($header)), "\r\n");
     }
 }

--- a/src/Response/ParsedResponse.php
+++ b/src/Response/ParsedResponse.php
@@ -17,18 +17,19 @@ final readonly class ParsedResponse
     public function lastHeaderBlock(): string
     {
         preg_match_all(
-            '/^HTTP\/[\d.]+\s+\d+\s+[^\r\n]*\r?\n(?:[^\r\n]+\r?\n)*?\r?\n/m',
+            '/^HTTP\/[\d.]+\s+\d+\s+[^\r\n]*(?:\r?\n[^\r\n]*)*?\r?\n\r?\n/m',
             $this->raw,
             $matches,
         );
         /** @var array{0: list<string>} $matches */
-        $blocks = array_map(
-            fn (string $match): string => trim($match),
-            $matches[0],
-        );
+        $blocks = $matches[0];
         $last = end($blocks);
 
-        return $last === false ? '' : $last;
+        if ($last === false) {
+            return '';
+        }
+
+        return rtrim($last, "\r\n");
     }
 
     /** @return array<string,string> */
@@ -37,24 +38,27 @@ final readonly class ParsedResponse
         $lines = preg_split('/\r?\n/', $this->lastHeaderBlock()) ?: [];
         array_shift($lines);
 
-        /** @var array<string,string> $headers */
         $headers = [];
         foreach ($lines as $line) {
-            if (preg_match('/^([^:]+):\s*(.+)$/', $line, $matches)) {
+            if (preg_match('/^([^:]+):\s*(.*)$/', $line, $matches)) {
                 $headers[trim($matches[1])] = trim($matches[2]);
             }
         }
-
         return $headers;
     }
 
     public function body(): string
     {
         $header = $this->lastHeaderBlock();
-        $offset = strpos($this->raw, $header);
+        if ($header === '') {
+            return $this->raw;
+        }
 
-        return $offset === false
-            ? $this->raw
-            : ltrim(substr($this->raw, $offset + strlen($header)), "\r\n");
+        $pos = strrpos($this->raw, "\r\n\r\n");
+        if ($pos === false) {
+            return $this->raw;
+        }
+
+        return substr($this->raw, $pos + 4);
     }
 }

--- a/src/Response/StatusCode.php
+++ b/src/Response/StatusCode.php
@@ -26,11 +26,6 @@ final readonly class StatusCode
         return $this->isInRange(200, 300);
     }
 
-    public function isRedirect(): bool
-    {
-        return $this->isInRange(300, 400);
-    }
-
     public function isInRange(int $min, int $max): bool
     {
         $code = $this->value();

--- a/tests/Response/CurlInfoTest.php
+++ b/tests/Response/CurlInfoTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
+ * SPDX-License-Identifier: MIT
+ */
+declare(strict_types=1);
+
+namespace Carl\Tests\Response;
+
+use Carl\Response\CurlInfo;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CurlInfoTest extends TestCase
+{
+    #[Test]
+    public function returnsStringValueWhenScalarPresent(): void
+    {
+        $this->assertSame(
+            '200',
+            new CurlInfo([CURLINFO_RESPONSE_CODE => 200])->value(CURLINFO_RESPONSE_CODE),
+            'Must return scalar value as string'
+        );
+    }
+
+    #[Test]
+    public function returnsDefaultWhenKeyMissing(): void
+    {
+        $this->assertSame(
+            'n/a',
+            new CurlInfo([])->value('missing', 'n/a'),
+            'Must return default when key is absent or non-scalar'
+        );
+    }
+
+    #[Test]
+    public function returnsHasKeyWhenPresent(): void
+    {
+        $this->assertTrue(
+            new CurlInfo(['x' => 1])->hasKey('x'),
+            'Must detect existing key'
+        );
+    }
+
+    #[Test]
+    public function returnsAllWhenRequested(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            new CurlInfo(['a' => 1, 'b' => 2])->all(),
+            'Must return full info array'
+        );
+    }
+}

--- a/tests/Response/CurlInfoTest.php
+++ b/tests/Response/CurlInfoTest.php
@@ -20,7 +20,7 @@ final class CurlInfoTest extends TestCase
         $this->assertSame(
             '200',
             new CurlInfo([CURLINFO_RESPONSE_CODE => 200])->value(CURLINFO_RESPONSE_CODE),
-            'Must return scalar value as string'
+            'Must return scalar value as string',
         );
     }
 
@@ -30,7 +30,7 @@ final class CurlInfoTest extends TestCase
         $this->assertSame(
             'n/a',
             new CurlInfo([])->value('missing', 'n/a'),
-            'Must return default when key is absent or non-scalar'
+            'Must return default when key is absent or non-scalar',
         );
     }
 
@@ -39,7 +39,7 @@ final class CurlInfoTest extends TestCase
     {
         $this->assertTrue(
             new CurlInfo(['x' => 1])->hasKey('x'),
-            'Must detect existing key'
+            'Must detect existing key',
         );
     }
 
@@ -49,7 +49,17 @@ final class CurlInfoTest extends TestCase
         $this->assertSame(
             ['a' => 1, 'b' => 2],
             new CurlInfo(['a' => 1, 'b' => 2])->all(),
-            'Must return full info array'
+            'Must return full info array',
+        );
+    }
+
+    #[Test]
+    public function returnsDefaultWhenValueIsNonScalar(): void
+    {
+        $this->assertSame(
+            'n/a',
+            new CurlInfo(['x' => ['nested']])->value('x', 'n/a'),
+            'Must return default when value is non-scalar',
         );
     }
 }

--- a/tests/Response/JsonResponseTest.php
+++ b/tests/Response/JsonResponseTest.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
 
 namespace Carl\Tests\Response;
 
-use Carl\Exception;
 use Carl\Response\Fake\SuccessResponse;
 use Carl\Response\JsonResponse;
+use JsonException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -22,14 +22,14 @@ final class JsonResponseTest extends TestCase
         $this->assertSame(
             ['a' => 1, 'b' => ['c' => 2]],
             new JsonResponse(new SuccessResponse('{"a":1,"b":{"c":2}}'))->json(),
-            'Must decode valid JSON into associative array'
+            'Must decode valid JSON into associative array',
         );
     }
 
     #[Test]
     public function throwsWhenRootIsNotArrayOrObject(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(JsonException::class);
 
         new JsonResponse(new SuccessResponse('"str"'))->json();
     }
@@ -40,7 +40,24 @@ final class JsonResponseTest extends TestCase
         $this->assertSame(
             '{"k":42}',
             new JsonResponse(new SuccessResponse('{"k":42}'))->body(),
-            'Must proxy body() from origin'
+            'Must proxy body() from origin',
         );
+    }
+
+    #[Test]
+    public function returnsArrayWhenArrayRoot(): void
+    {
+        $this->assertSame(
+            [1, 2, 3],
+            new JsonResponse(new SuccessResponse('[1,2,3]'))->json(),
+            'Must accept array root',
+        );
+    }
+
+    #[Test]
+    public function throwsJsonExceptionOnMalformedJson(): void
+    {
+        $this->expectException(JsonException::class);
+        new JsonResponse(new SuccessResponse('{"a": '))->json();
     }
 }

--- a/tests/Response/JsonResponseTest.php
+++ b/tests/Response/JsonResponseTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
+ * SPDX-License-Identifier: MIT
+ */
+declare(strict_types=1);
+
+namespace Carl\Tests\Response;
+
+use Carl\Exception;
+use Carl\Response\Fake\SuccessResponse;
+use Carl\Response\JsonResponse;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class JsonResponseTest extends TestCase
+{
+    #[Test]
+    public function returnsArrayWhenValidJson(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => ['c' => 2]],
+            new JsonResponse(new SuccessResponse('{"a":1,"b":{"c":2}}'))->json(),
+            'Must decode valid JSON into associative array'
+        );
+    }
+
+    #[Test]
+    public function throwsWhenRootIsNotArrayOrObject(): void
+    {
+        $this->expectException(Exception::class);
+
+        new JsonResponse(new SuccessResponse('"str"'))->json();
+    }
+
+    #[Test]
+    public function returnsBodyPassThroughWhenCalled(): void
+    {
+        $this->assertSame(
+            '{"k":42}',
+            new JsonResponse(new SuccessResponse('{"k":42}'))->body(),
+            'Must proxy body() from origin'
+        );
+    }
+}

--- a/tests/Response/ParsedResponseTest.php
+++ b/tests/Response/ParsedResponseTest.php
@@ -49,12 +49,59 @@ final class ParsedResponseTest extends TestCase
     }
 
     #[Test]
+    public function returnsRawWhenNoHeadersAndLeadingCrlf(): void
+    {
+        $this->assertSame(
+            "\r\nBODY",
+            new ParsedResponse("\r\nBODY")->body(),
+            'Must preserve raw when no headers are present'
+        );
+    }
+
+    #[Test]
+    public function returnsBodyForLastHeaderBlockWhenDuplicate(): void
+    {
+        $raw =
+            "HTTP/1.1 301 Moved\r\nH: a\r\n\r\nOLD" .
+            "HTTP/1.1 200 OK\r\nH: b\r\n\r\nNEW";
+        $this->assertSame(
+            'NEW',
+            new ParsedResponse($raw)->body(),
+            'Must return body after the last header block'
+        );
+    }
+
+    #[Test]
     public function returnsRawWhenNoHeaders(): void
     {
         $this->assertSame(
             'RAW',
             new ParsedResponse('RAW')->body(),
             'Must return raw content when no headers found'
+        );
+    }
+
+    #[Test]
+    public function returnsBodyAfterLastDuplicateHeaderBlock(): void
+    {
+        // Два одинаковых блока; тело должно быть после последнего
+        $raw = "HTTP/1.1 200 OK\r\nX: a\r\n\r\nFirst"
+            . "\r\nHTTP/1.1 200 OK\r\nX: a\r\n\r\nSecond";
+        $this->assertSame(
+            'Second',
+            new ParsedResponse($raw)->body(),
+            'Must use the last matching header block when duplicates occur'
+        );
+    }
+
+    #[Test]
+    public function preservesRawWhenNoHeadersEvenIfStartsWithNewlines(): void
+    {
+        $raw = "\r\n\nRAW";
+        $this->assertSame(
+            $raw,
+            new ParsedResponse($raw)->body(),
+            'Must not trim raw when no headers are present'
         );
     }
 }

--- a/tests/Response/ParsedResponseTest.php
+++ b/tests/Response/ParsedResponseTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
+ * SPDX-License-Identifier: MIT
+ */
+declare(strict_types=1);
+
+namespace Carl\Tests\Response;
+
+use Carl\Response\ParsedResponse;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ParsedResponseTest extends TestCase
+{
+    #[Test]
+    public function returnsLastHeaderBlockWhenMultiplePresent(): void
+    {
+        $raw = "HTTP/1.1 301 Moved\r\nH1: a\r\n\r\n" .
+            "HTTP/1.1 200 OK\r\nH2: b\r\n\r\nBODY";
+        $this->assertSame(
+            "HTTP/1.1 200 OK\r\nH2: b",
+            new ParsedResponse($raw)->lastHeaderBlock(),
+            'Must extract the last header block'
+        );
+    }
+
+    #[Test]
+    public function returnsHeadersWhenParsed(): void
+    {
+        $raw = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nX-Id: 7\r\n\r\nok";
+        $this->assertSame(
+            ['Content-Type' => 'text/plain', 'X-Id' => '7'],
+            new ParsedResponse($raw)->headers(),
+            'Must parse header lines into an associative array'
+        );
+    }
+
+    #[Test]
+    public function returnsBodyWhenHeadersPresent(): void
+    {
+        $raw = "HTTP/1.1 200 OK\r\nA: 1\r\n\r\nHello";
+        $this->assertSame(
+            'Hello',
+            new ParsedResponse($raw)->body(),
+            'Must return body after the last header block'
+        );
+    }
+
+    #[Test]
+    public function returnsRawWhenNoHeaders(): void
+    {
+        $this->assertSame(
+            'RAW',
+            new ParsedResponse('RAW')->body(),
+            'Must return raw content when no headers found'
+        );
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * More robust response parsing: body extraction now uses the last header block, handles empty header values, and preserves raw content when no headers exist.
  * JSON responses now validate root types and raise JSON errors for scalar roots.

* Refactor
  * Removed the redirect-check helper from the status code API.

* Tests
  * Added unit tests for JSON decoding, parsed-response behavior, and cURL info access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->