### PR TITLE
Response: use string keys from curl_getinfo instead of numeric constants; update tests accordingly

### DIFF
--- a/src/Outcome/Fake/AlwaysSuccessful.php
+++ b/src/Outcome/Fake/AlwaysSuccessful.php
@@ -39,7 +39,7 @@ final readonly class AlwaysSuccessful implements FakeOutcomes
             new CurlResponse(
                 $this->body,
                 ['Content-Type' => 'text/plain'],
-                new CurlInfo([CURLINFO_RESPONSE_CODE => $this->code])
+                new CurlInfo(['http_code' => $this->code])
             )
         );
     }

--- a/src/Outcome/Fake/FakeStatus.php
+++ b/src/Outcome/Fake/FakeStatus.php
@@ -29,7 +29,7 @@ use Override;
  *     ->outcome(new GetRequest("http://localhost/404"))
  *     ->response()
  *     ->info()
- *     ->value(CURLINFO_RESPONSE_CODE); // 404
+ *     ->value('http_code'); // 404
  *
  * @codeCoverageIgnore
  */
@@ -56,7 +56,7 @@ final readonly class FakeStatus implements FakeOutcomes
             new CurlResponse(
                 'ok',
                 ['Content-Type' => 'text/plain'],
-                new CurlInfo([CURLINFO_RESPONSE_CODE => $code]),
+                new CurlInfo(['http_code' => $code]),
             ),
         );
     }

--- a/src/Outcome/Fake/RandomOutcomes.php
+++ b/src/Outcome/Fake/RandomOutcomes.php
@@ -77,7 +77,7 @@ final readonly class RandomOutcomes implements FakeOutcomes
             new CurlResponse(
                 json_encode(['status' => $code, 'message' => "response:$code"], JSON_THROW_ON_ERROR),
                 ['Content-Type' => 'application/json; charset=utf-8'],
-                new CurlInfo([CURLINFO_RESPONSE_CODE => $code]),
+                new CurlInfo(['http_code' => $code]),
             ),
         );
     }

--- a/src/Response/CurlInfo.php
+++ b/src/Response/CurlInfo.php
@@ -8,6 +8,17 @@ declare(strict_types=1);
 
 namespace Carl\Response;
 
+/**
+ * Immutable wrapper around the array returned by curl_getinfo().
+ *
+ * Provides safe access to cURL transfer metadata such as 'url',
+ * 'content_type', 'http_code', etc. Keys may be accessed by their
+ * string names as defined by curl_getinfo().
+ *
+ * Example:
+ * $info = new CurlInfo(curl_getinfo($handle));
+ * $code = $info->value('http_code'); // e.g. 200
+ */
 final readonly class CurlInfo
 {
     /** @param array<string|int, mixed> $info */

--- a/src/Response/CurlPayload.php
+++ b/src/Response/CurlPayload.php
@@ -8,6 +8,19 @@ declare(strict_types=1);
 
 namespace Carl\Response;
 
+/**
+ * Immutable wrapper around the raw cURL payload string.
+ *
+ * Splits the raw content returned by curl_multi_getcontent()
+ * into headers and body. Correctly handles multiple HTTP
+ * response blocks (e.g. redirects), always using the last
+ * header block when extracting headers.
+ *
+ * Example:
+ * $payload = new CurlPayload($raw);
+ * $headers = $payload->headers(); // associative array
+ * $body    = $payload->body();    // string body
+ */
 final readonly class CurlPayload
 {
     public function __construct(private string $raw)

--- a/src/Response/CurlResponse.php
+++ b/src/Response/CurlResponse.php
@@ -10,6 +10,18 @@ namespace Carl\Response;
 
 use Override;
 
+/**
+ * Immutable HTTP response backed by cURL data.
+ *
+ * Combines body, parsed headers, and CurlInfo metadata
+ * into a single Response implementation.
+ *
+ * Example:
+ * $response = new CurlResponse($body, $headers, $info);
+ * echo $response->body();
+ * print_r($response->headers());
+ * echo $response->info()->value('http_code');
+ */
 final readonly class CurlResponse implements Response
 {
     /**

--- a/src/Response/EffectiveUrl.php
+++ b/src/Response/EffectiveUrl.php
@@ -8,6 +8,15 @@ declare(strict_types=1);
 
 namespace Carl\Response;
 
+/**
+ * Value object for extracting the effective URL from a Response.
+ *
+ * Wraps a Response and exposes the final URL that cURL reports
+ * after any redirects. Uses the 'url' key from curl_getinfo().
+ *
+ * Example:
+ * $url = (new EffectiveUrl($response))->value();
+ */
 final readonly class EffectiveUrl
 {
     public function __construct(private Response $response)
@@ -16,6 +25,6 @@ final readonly class EffectiveUrl
 
     public function value(): string
     {
-        return $this->response->info()->value(CURLINFO_EFFECTIVE_URL);
+        return $this->response->info()->value('url');
     }
 }

--- a/src/Response/Fake/ClientErrorResponse.php
+++ b/src/Response/Fake/ClientErrorResponse.php
@@ -42,7 +42,7 @@ final readonly class ClientErrorResponse implements Response
     public function info(): CurlInfo
     {
         return new CurlInfo([
-            CURLINFO_RESPONSE_CODE => 400,
+            'http_code' => 400,
         ]);
     }
 }

--- a/src/Response/Fake/NotFoundResponse.php
+++ b/src/Response/Fake/NotFoundResponse.php
@@ -22,7 +22,7 @@ use Override;
  *
  * Example:
  * $response = new NotFoundResponse();
- * echo $response->info()->value(CURLINFO_RESPONSE_CODE); // 404
+ * echo $response->info()->value('http_code'); // 404
  */
 final readonly class NotFoundResponse implements Response
 {
@@ -46,7 +46,8 @@ final readonly class NotFoundResponse implements Response
     public function info(): CurlInfo
     {
         return new CurlInfo([
-            CURLINFO_RESPONSE_CODE => 404,
+            'http_code' => 404,
         ]);
     }
 }
+

--- a/src/Response/Fake/RedirectResponse.php
+++ b/src/Response/Fake/RedirectResponse.php
@@ -22,7 +22,8 @@ use Override;
  *
  * Example:
  * $response = new RedirectResponse("https://example.com/next");
- * echo $response->headers()['Location']; // https://example.com/next
+ * echo $response->headers()['Location'];      // https://example.com/next
+ * echo $response->info()->value('http_code'); // 302
  */
 final readonly class RedirectResponse implements Response
 {
@@ -51,8 +52,8 @@ final readonly class RedirectResponse implements Response
     public function info(): CurlInfo
     {
         return new CurlInfo([
-            CURLINFO_RESPONSE_CODE => 302,
-            CURLINFO_REDIRECT_URL => $this->location,
+            'http_code'    => 302,
+            'redirect_url' => $this->location,
         ]);
     }
 }

--- a/src/Response/Fake/ServerErrorResponse.php
+++ b/src/Response/Fake/ServerErrorResponse.php
@@ -22,7 +22,7 @@ use Override;
  *
  * Example:
  * $response = new ServerErrorResponse("Something went wrong");
- * echo $response->info()->value(CURLINFO_RESPONSE_CODE); // 500
+ * echo $response->info()->value('http_code'); // 500
  */
 final readonly class ServerErrorResponse implements Response
 {
@@ -46,7 +46,7 @@ final readonly class ServerErrorResponse implements Response
     public function info(): CurlInfo
     {
         return new CurlInfo([
-            CURLINFO_RESPONSE_CODE => 500,
+            'http_code' => 500,
         ]);
     }
 }

--- a/src/Response/Fake/SuccessResponse.php
+++ b/src/Response/Fake/SuccessResponse.php
@@ -46,7 +46,7 @@ final readonly class SuccessResponse implements Response
     public function info(): CurlInfo
     {
         return new CurlInfo([
-            CURLINFO_RESPONSE_CODE => 200,
+            'http_code' => 200,
         ]);
     }
 }

--- a/src/Response/Fake/UnauthorizedResponse.php
+++ b/src/Response/Fake/UnauthorizedResponse.php
@@ -19,6 +19,10 @@ use Override;
  *
  * Useful in tests to simulate cases where authentication
  * is required or the provided credentials are invalid.
+ *
+ * Example:
+ * $response = new UnauthorizedResponse();
+ * echo $response->info()->value('http_code'); // 401
  */
 final readonly class UnauthorizedResponse implements Response
 {
@@ -42,7 +46,7 @@ final readonly class UnauthorizedResponse implements Response
     public function info(): CurlInfo
     {
         return new CurlInfo([
-            CURLINFO_RESPONSE_CODE => 401,
+            'http_code' => 401,
         ]);
     }
 }

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -13,6 +13,18 @@ use function is_array;
 use JsonException;
 use Override;
 
+/**
+ * Response decorator for JSON payloads.
+ *
+ * Delegates body, headers, and info to the origin response,
+ * but adds a decoded() method that parses the body as JSON.
+ * Decoding uses associative arrays and throws JsonException
+ * on invalid JSON or if the root value is not an object/array.
+ *
+ * Example:
+ * $response = new JsonResponse($origin);
+ * $data = $response->decoded(); // array from JSON body
+ */
 final readonly class JsonResponse implements Response
 {
     public function __construct(

--- a/src/Response/PrimaryIp.php
+++ b/src/Response/PrimaryIp.php
@@ -8,6 +8,15 @@ declare(strict_types=1);
 
 namespace Carl\Response;
 
+/**
+ * Value object for extracting the primary IP address from a Response.
+ *
+ * Wraps a Response and exposes the resolved IP address of the connection
+ * as reported by curl_getinfo() under the 'primary_ip' key.
+ *
+ * Example:
+ * $ip = (new PrimaryIp($response))->value(); // e.g. "93.184.216.34"
+ */
 final readonly class PrimaryIp
 {
     public function __construct(private Response $response)
@@ -16,6 +25,6 @@ final readonly class PrimaryIp
 
     public function value(): string
     {
-        return $this->response->info()->value(CURLINFO_PRIMARY_IP, '0.0.0.0');
+        return $this->response->info()->value('primary_ip', '0.0.0.0');
     }
 }

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -11,7 +11,7 @@ namespace Carl\Response;
 /**
  * Represents an HTTP response.
  *
- * Provides access to response body, headers and cURL transfer info.
+ * Provides access to response body, headers, and cURL transfer info.
  * Used by Outcomes to wrap results of HTTP requests.
  */
 interface Response
@@ -22,16 +22,16 @@ interface Response
     public function body(): string;
 
     /**
+     * Response headers as an associative array.
+     *
+     * @return array<string,string> HTTP headers
+     *         Keys are case-insensitive; implementation may or may not preserve original casing
+     */
+    public function headers(): array;
+
+    /**
      * cURL transfer info associated with this response.
      * Useful for retrieving HTTP status codes, timing info, etc.
      */
     public function info(): CurlInfo;
-
-    /**
-     * Response headers as an associative array.
-     *
-     * @return array<string,string> HTTP headers.
-     *         Keys are case-insensitive; implementation may or may not preserve original casing
-     */
-    public function headers(): array;
 }

--- a/src/Response/StatusCode.php
+++ b/src/Response/StatusCode.php
@@ -8,6 +8,18 @@ declare(strict_types=1);
 
 namespace Carl\Response;
 
+/**
+ * Value object for extracting the HTTP status code from a Response.
+ *
+ * Wraps a Response and exposes helpers to check its status code,
+ * using the 'http_code' key from curl_getinfo().
+ *
+ * Example:
+ * $status = new StatusCode($response);
+ * if ($status->isSuccessful()) {
+ *     // 2xx range
+ * }
+ */
 final readonly class StatusCode
 {
     public function __construct(private Response $response)
@@ -16,7 +28,7 @@ final readonly class StatusCode
 
     public function value(): int
     {
-        return (int) $this->response->info()->value(CURLINFO_RESPONSE_CODE);
+        return (int) $this->response->info()->value('http_code');
     }
 
     public function isSuccessful(): bool

--- a/src/Response/WithContentType.php
+++ b/src/Response/WithContentType.php
@@ -10,6 +10,17 @@ namespace Carl\Response;
 
 use Override;
 
+/**
+ * Response decorator that overrides the Content-Type header.
+ *
+ * Replaces or adds the 'Content-Type' entry in the response headers
+ * while delegating all other data to the origin response.
+ *
+ * Example:
+ * $response = new WithContentType($origin, 'application/json');
+ * $headers  = $response->headers();
+ * // 'Content-Type' => 'application/json'
+ */
 final readonly class WithContentType implements Response
 {
     public function __construct(

--- a/src/Response/WithStatusCode.php
+++ b/src/Response/WithStatusCode.php
@@ -10,6 +10,16 @@ namespace Carl\Response;
 
 use Override;
 
+/**
+ * Response decorator that overrides the HTTP status code.
+ *
+ * Ensures that CurlInfo contains the provided code under the 'http_code' key,
+ * which is the same format as produced by curl_getinfo().
+ *
+ * Example:
+ * $response = new WithStatusCode($origin, 503);
+ * $status   = $response->info()->value('http_code'); // 503
+ */
 final readonly class WithStatusCode implements Response
 {
     public function __construct(
@@ -30,16 +40,11 @@ final readonly class WithStatusCode implements Response
         return $this->origin->headers();
     }
 
-    /**
-     * Adds both 'CURLINFO_RESPONSE_CODE' (curl constant) and 'http_code' (legacy array key)
-     * to preserve compatibility with all consumers of CurlInfo.
-     */
     #[Override]
     public function info(): CurlInfo
     {
         return new CurlInfo([
             ...$this->origin->info()->all(),
-            CURLINFO_RESPONSE_CODE => $this->code,
             'http_code' => $this->code,
         ]);
     }

--- a/tests/Unit/Response/CurlInfoTest.php
+++ b/tests/Unit/Response/CurlInfoTest.php
@@ -19,7 +19,7 @@ final class CurlInfoTest extends TestCase
     {
         $this->assertSame(
             '200',
-            new CurlInfo([CURLINFO_RESPONSE_CODE => 200])->value(CURLINFO_RESPONSE_CODE),
+            new CurlInfo(['http_code' => 200])->value('http_code'),
             'Must return scalar value as string',
         );
     }

--- a/tests/Unit/Response/EffectiveUrlTest.php
+++ b/tests/Unit/Response/EffectiveUrlTest.php
@@ -25,8 +25,8 @@ final class EffectiveUrlTest extends TestCase
             body: 'Redirected',
             headers: ['Content-Type' => 'text/html'],
             curlInfo: new CurlInfo([
-                CURLINFO_EFFECTIVE_URL => $url,
-                CURLINFO_RESPONSE_CODE => 200,
+                'url'       => $url,
+                'http_code' => 200,
             ]),
         );
 

--- a/tests/Unit/Response/PrimaryIpTest.php
+++ b/tests/Unit/Response/PrimaryIpTest.php
@@ -23,7 +23,7 @@ final class PrimaryIpTest extends TestCase
             body: '...',
             headers: [],
             curlInfo: new CurlInfo([
-                CURLINFO_PRIMARY_IP => '192.168.1.100',
+                'primary_ip' => '192.168.1.100',
             ]),
         );
 
@@ -56,7 +56,7 @@ final class PrimaryIpTest extends TestCase
         $response = new CurlResponse(
             body: '...',
             headers: [],
-            curlInfo: new CurlInfo([CURLINFO_PRIMARY_IP => '2001:db8::1']),
+            curlInfo: new CurlInfo(['primary_ip' => '2001:db8::1']),
         );
 
         $this->assertSame('2001:db8::1', new PrimaryIp($response)->value());

--- a/tests/Unit/Response/StatusCodeTest.php
+++ b/tests/Unit/Response/StatusCodeTest.php
@@ -22,7 +22,7 @@ final class StatusCodeTest extends TestCase
     {
         $status = new StatusCode(
             new CurlResponse('...', [], new CurlInfo([
-                CURLINFO_RESPONSE_CODE => 201,
+                'http_code' => 201,
             ])),
         );
 
@@ -37,7 +37,7 @@ final class StatusCodeTest extends TestCase
     {
         $status = new StatusCode(
             new CurlResponse('irrelevant', [], new CurlInfo([
-                CURLINFO_RESPONSE_CODE => $code,
+                'http_code' => $code,
             ])),
         );
 
@@ -56,7 +56,7 @@ final class StatusCodeTest extends TestCase
     {
         $status = new StatusCode(
             new CurlResponse('irrelevant', [], new CurlInfo([
-                CURLINFO_RESPONSE_CODE => $code,
+                'http_code' => $code,
             ])),
         );
 
@@ -71,7 +71,7 @@ final class StatusCodeTest extends TestCase
     {
         $status = new StatusCode(
             new CurlResponse('...', [], new CurlInfo([
-                CURLINFO_RESPONSE_CODE => 404,
+                'http_code' => 404,
             ])),
         );
 
@@ -83,7 +83,7 @@ final class StatusCodeTest extends TestCase
     {
         $status = new StatusCode(
             new CurlResponse('...', [], new CurlInfo([
-                CURLINFO_RESPONSE_CODE => 301,
+                'http_code' => 301,
             ])),
         );
 

--- a/tests/Unit/Response/WithStatusCodeTest.php
+++ b/tests/Unit/Response/WithStatusCodeTest.php
@@ -35,21 +35,6 @@ final class WithStatusCodeTest extends TestCase
     }
 
     #[Test]
-    public function overridesCurlInfoConstantWhenWrapped(): void
-    {
-        $response = new WithStatusCode(
-            new CurlResponse('irrelevant', [], new CurlInfo(['http_code' => 500])),
-            201,
-        );
-
-        $this->assertSame(
-            201,
-            (int)$response->info()->value(CURLINFO_RESPONSE_CODE),
-            'Should also set CURLINFO_RESPONSE_CODE',
-        );
-    }
-
-    #[Test]
     public function returnsBodyFromOriginWhenCalled(): void
     {
         $response = new WithStatusCode(


### PR DESCRIPTION
### What changed
- Replaced CURLINFO_* numeric constants with string keys from `curl_getinfo()`.
- Updated all Response value objects (StatusCode, EffectiveUrl, PrimaryIp).
- Updated FakeResponse classes to return string keys.
- Updated unit tests accordingly.

### Why
- Align with real behavior of `curl_getinfo()`.
- Ensure consistency between production code, fakes, and tests.