### PR TITLE
feat/limited-client

### DIFF
--- a/src/Client/LimitedClient.php
+++ b/src/Client/LimitedClient.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
+ * SPDX-License-Identifier: MIT
+ */
+declare(strict_types=1);
+
+namespace Carl\Client;
+
+use Carl\Outcome\Outcome;
+use Carl\Reaction\Reaction;
+use Carl\Reaction\VoidReaction;
+use Carl\Request\Request;
+use Override;
+
+/**
+ * Client decorator that enforces a maximum number of requests.
+ *
+ * Ignores any requests beyond the configured limit.
+ */
+final readonly class LimitedClient implements Client
+{
+    /**
+     * @param int<1,max> $limit Maximum number of requests to execute
+     */
+    public function __construct(
+        private Client $origin,
+        private int $limit,
+    ) {
+    }
+
+    #[Override]
+    public function outcome(Request $request, Reaction $reaction = new VoidReaction()): Outcome
+    {
+        return $this->origin->outcome($request, $reaction);
+    }
+
+    #[Override]
+    public function outcomes(iterable $requests, Reaction $reaction = new VoidReaction()): array
+    {
+        $limited = (function () use ($requests) {
+            $count = 0;
+            foreach ($requests as $request) {
+                if ($count++ >= $this->limit) {
+                    break;
+                }
+                yield $request;
+            }
+        })();
+
+        return $this->origin->outcomes($limited, $reaction);
+    }
+}

--- a/src/Client/LimitedClient.php
+++ b/src/Client/LimitedClient.php
@@ -47,10 +47,11 @@ final readonly class LimitedClient implements Client
         $limited = (function () use ($requests) {
             $count = 0;
             foreach ($requests as $request) {
-                if ($count++ >= $this->limit) {
+                if ($count >= $this->limit) {
                     break;
                 }
                 yield $request;
+                $count++;
             }
         })();
 

--- a/src/Client/LimitedClient.php
+++ b/src/Client/LimitedClient.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Carl\Client;
 
+use Carl\Exception;
 use Carl\Outcome\Outcome;
 use Carl\Reaction\Reaction;
 use Carl\Reaction\VoidReaction;
@@ -22,7 +23,7 @@ use Override;
 final readonly class LimitedClient implements Client
 {
     /**
-     * @param int<1,max> $limit Maximum number of requests to execute
+     * @param int $limit Maximum number of requests to execute
      */
     public function __construct(
         private Client $origin,
@@ -39,6 +40,10 @@ final readonly class LimitedClient implements Client
     #[Override]
     public function outcomes(iterable $requests, Reaction $reaction = new VoidReaction()): array
     {
+        if ($this->limit < 1) {
+            throw new Exception("Limit must be >= 1, got $this->limit");
+        }
+
         $limited = (function () use ($requests) {
             $count = 0;
             foreach ($requests as $request) {

--- a/tests/Unit/Client/LimitedClientTest.php
+++ b/tests/Unit/Client/LimitedClientTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
+ * SPDX-License-Identifier: MIT
+ */
+declare(strict_types=1);
+
+namespace Carl\Tests\Unit\Client;
+
+use Carl\Client\Fake\FakeClient;
+use Carl\Client\LimitedClient;
+use Carl\Outcome\Fake\AlwaysSuccessful;
+use Carl\Outcome\Fake\FakeStatus;
+use Carl\Request\GetRequest;
+use Carl\Tests\Integration\Support\AssertsHttpResponse;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class LimitedClientTest extends TestCase
+{
+    use AssertsHttpResponse;
+
+    #[Test]
+    public function delegatesOutcomeToOrigin(): void
+    {
+        $client = new LimitedClient(
+            new FakeClient(new AlwaysSuccessful(202, 'pong')),
+            1
+        );
+
+        $outcome = $client->outcome(new GetRequest('http://localhost/ping'));
+
+        $this->assertStatusCode(
+            $outcome->response(),
+            202,
+            'Must delegate outcome() to origin client'
+        );
+    }
+
+    #[Test]
+    public function stopsAfterLimitReached(): void
+    {
+        $client = new LimitedClient(
+            new FakeClient(new FakeStatus()),
+            2
+        );
+
+        $requests = [
+            new GetRequest('http://localhost/201'),
+            new GetRequest('http://localhost/404'),
+            new GetRequest('http://localhost/302'),
+        ];
+
+        $outcomes = $client->outcomes($requests);
+
+        $this->assertCount(2, $outcomes, 'Must only execute first N requests when limit is set');
+
+        $this->assertStatusCode($outcomes[0]->response(), 201);
+        $this->assertStatusCode($outcomes[1]->response(), 404);
+    }
+
+    #[Test]
+    public function emptyInputReturnsEmptyArray(): void
+    {
+        $client = new LimitedClient(new FakeClient(new AlwaysSuccessful()), 3);
+
+        $this->assertSame([], $client->outcomes([]), 'Must return empty array for empty input');
+    }
+
+    #[Test]
+    public function limitLargerThanRequestsExecutesAll(): void
+    {
+        $client = new LimitedClient(new FakeClient(new FakeStatus()), 10);
+
+        $requests = [
+            new GetRequest('http://localhost/201'),
+            new GetRequest('http://localhost/500'),
+        ];
+
+        $outcomes = $client->outcomes($requests);
+
+        $this->assertCount(2, $outcomes, 'Must execute all requests if less than limit');
+
+        $this->assertStatusCode($outcomes[0]->response(), 201);
+        $this->assertStatusCode($outcomes[1]->response(), 500);
+    }
+}


### PR DESCRIPTION
### What changed
- Introduced `LimitedClient` decorator.
- Limits number of requests passed to origin client.
- Added `LimitedClientTest`.

### Why
- Provides a clean way to cap requests per scenario.
- Completes the set of Client decorators (`ChunkedClient`, `ThrottledClient`, `LimitedClient`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to cap how many requests are processed per batch.
  * Enforces a minimum limit of 1 and raises an error if configured lower.
  * Requests beyond the configured cap are ignored; single-request behavior remains unchanged.

* **Tests**
  * Added unit tests covering delegation, limit enforcement (under/over), empty input, and iterator-limited processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->