### PR TITLE
feat(fake-responses): add required headers and info fields

### DIFF
--- a/src/Response/Fake/ClientErrorResponse.php
+++ b/src/Response/Fake/ClientErrorResponse.php
@@ -22,9 +22,7 @@ use Override;
  */
 final readonly class ClientErrorResponse implements Response
 {
-    public function __construct(private string $message = 'Bad Request')
-    {
-    }
+    public function __construct(private string $message = 'Bad Request') {}
 
     #[Override]
     public function body(): string
@@ -35,7 +33,13 @@ final readonly class ClientErrorResponse implements Response
     #[Override]
     public function headers(): array
     {
-        return ['Content-Type' => 'text/plain'];
+        return [
+            'Content-Type' => 'text/plain; charset=utf-8',
+            'Content-Length' => (string)strlen($this->message),
+            'Server' => 'FakeServer/1.0',
+            'Date' => gmdate('D, d M Y H:i:s') . ' GMT',
+            'Connection' => 'close',
+        ];
     }
 
     #[Override]
@@ -43,6 +47,22 @@ final readonly class ClientErrorResponse implements Response
     {
         return new CurlInfo([
             'http_code' => 400,
+            'total_time' => 0.001,
+            'namelookup_time' => 0.0,
+            'connect_time' => 0.0,
+            'appconnect_time' => 0.0,
+            'pretransfer_time' => 0.0,
+            'starttransfer_time' => 0.001,
+            'redirect_time' => 0.0,
+            'redirect_count' => 0,
+            'size_download' => strlen($this->message),
+            'size_upload' => 0,
+            'speed_download' => strlen($this->message) * 1000,
+            'speed_upload' => 0,
+            'url' => 'http://fake.local/client-error',
+            'primary_ip' => '127.0.0.1',
+            'content_type' => 'text/plain; charset=utf-8',
+            'redirect_url' => '',
         ]);
     }
 }

--- a/src/Response/Fake/NotFoundResponse.php
+++ b/src/Response/Fake/NotFoundResponse.php
@@ -26,9 +26,7 @@ use Override;
  */
 final readonly class NotFoundResponse implements Response
 {
-    public function __construct(private string $message = 'Not Found')
-    {
-    }
+    public function __construct(private string $message = 'Not Found') {}
 
     #[Override]
     public function body(): string
@@ -39,7 +37,13 @@ final readonly class NotFoundResponse implements Response
     #[Override]
     public function headers(): array
     {
-        return ['Content-Type' => 'text/plain'];
+        return [
+            'Content-Type' => 'text/plain; charset=utf-8',
+            'Content-Length' => (string)strlen($this->message),
+            'Server' => 'FakeServer/1.0',
+            'Date' => gmdate('D, d M Y H:i:s') . ' GMT',
+            'Connection' => 'close',
+        ];
     }
 
     #[Override]
@@ -47,6 +51,22 @@ final readonly class NotFoundResponse implements Response
     {
         return new CurlInfo([
             'http_code' => 404,
+            'total_time' => 0.001,
+            'namelookup_time' => 0.0,
+            'connect_time' => 0.0,
+            'appconnect_time' => 0.0,
+            'pretransfer_time' => 0.0,
+            'starttransfer_time' => 0.001,
+            'redirect_time' => 0.0,
+            'redirect_count' => 0,
+            'size_download' => strlen($this->message),
+            'size_upload' => 0,
+            'speed_download' => strlen($this->message) * 1000,
+            'speed_upload' => 0,
+            'url' => 'http://fake.local/not-found',
+            'primary_ip' => '127.0.0.1',
+            'content_type' => 'text/plain; charset=utf-8',
+            'redirect_url' => '',
         ]);
     }
 }

--- a/src/Response/Fake/RedirectResponse.php
+++ b/src/Response/Fake/RedirectResponse.php
@@ -29,9 +29,8 @@ final readonly class RedirectResponse implements Response
 {
     public function __construct(
         private string $location,
-        private string $message = 'Redirecting...'
-    ) {
-    }
+        private string $message = 'Redirecting...',
+    ) {}
 
     #[Override]
     public function body(): string
@@ -43,8 +42,12 @@ final readonly class RedirectResponse implements Response
     public function headers(): array
     {
         return [
-            'Content-Type' => 'text/plain',
+            'Content-Type' => 'text/plain; charset=utf-8',
+            'Content-Length' => (string)strlen($this->message),
             'Location' => $this->location,
+            'Server' => 'FakeServer/1.0',
+            'Date' => gmdate('D, d M Y H:i:s') . ' GMT',
+            'Connection' => 'close',
         ];
     }
 
@@ -52,7 +55,22 @@ final readonly class RedirectResponse implements Response
     public function info(): CurlInfo
     {
         return new CurlInfo([
-            'http_code'    => 302,
+            'http_code' => 302,
+            'total_time' => 0.001,
+            'namelookup_time' => 0.0,
+            'connect_time' => 0.0,
+            'appconnect_time' => 0.0,
+            'pretransfer_time' => 0.0,
+            'starttransfer_time' => 0.001,
+            'redirect_time' => 0.001,
+            'redirect_count' => 1,
+            'size_download' => strlen($this->message),
+            'size_upload' => 0,
+            'speed_download' => strlen($this->message) * 1000,
+            'speed_upload' => 0,
+            'url' => 'http://fake.local/redirect',
+            'primary_ip' => '127.0.0.1',
+            'content_type' => 'text/plain; charset=utf-8',
             'redirect_url' => $this->location,
         ]);
     }

--- a/src/Response/Fake/ServerErrorResponse.php
+++ b/src/Response/Fake/ServerErrorResponse.php
@@ -26,9 +26,7 @@ use Override;
  */
 final readonly class ServerErrorResponse implements Response
 {
-    public function __construct(private string $message = 'Internal Server Error')
-    {
-    }
+    public function __construct(private string $message = 'Internal Server Error') {}
 
     #[Override]
     public function body(): string
@@ -39,7 +37,13 @@ final readonly class ServerErrorResponse implements Response
     #[Override]
     public function headers(): array
     {
-        return ['Content-Type' => 'text/plain'];
+        return [
+            'Content-Type' => 'text/plain; charset=utf-8',
+            'Content-Length' => (string)strlen($this->message),
+            'Server' => 'FakeServer/1.0',
+            'Date' => gmdate('D, d M Y H:i:s') . ' GMT',
+            'Connection' => 'close',
+        ];
     }
 
     #[Override]
@@ -47,6 +51,22 @@ final readonly class ServerErrorResponse implements Response
     {
         return new CurlInfo([
             'http_code' => 500,
+            'total_time' => 0.001,
+            'namelookup_time' => 0.0,
+            'connect_time' => 0.0,
+            'appconnect_time' => 0.0,
+            'pretransfer_time' => 0.0,
+            'starttransfer_time' => 0.001,
+            'redirect_time' => 0.0,
+            'redirect_count' => 0,
+            'size_download' => strlen($this->message),
+            'size_upload' => 0,
+            'speed_download' => strlen($this->message) * 1000,
+            'speed_upload' => 0,
+            'url' => 'http://fake.local/server-error',
+            'primary_ip' => '127.0.0.1',
+            'content_type' => 'text/plain; charset=utf-8',
+            'redirect_url' => '',
         ]);
     }
 }

--- a/src/Response/Fake/SuccessResponse.php
+++ b/src/Response/Fake/SuccessResponse.php
@@ -26,9 +26,7 @@ use Override;
  */
 final readonly class SuccessResponse implements Response
 {
-    public function __construct(private string $message = 'OK')
-    {
-    }
+    public function __construct(private string $message = 'OK') {}
 
     #[Override]
     public function body(): string
@@ -39,7 +37,13 @@ final readonly class SuccessResponse implements Response
     #[Override]
     public function headers(): array
     {
-        return ['Content-Type' => 'text/plain'];
+        return [
+            'Content-Type' => 'text/plain; charset=utf-8',
+            'Content-Length' => (string)strlen($this->message),
+            'Server' => 'FakeServer/1.0',
+            'Date' => gmdate('D, d M Y H:i:s') . ' GMT',
+            'Connection' => 'keep-alive',
+        ];
     }
 
     #[Override]
@@ -47,6 +51,22 @@ final readonly class SuccessResponse implements Response
     {
         return new CurlInfo([
             'http_code' => 200,
+            'total_time' => 0.001,
+            'namelookup_time' => 0.0,
+            'connect_time' => 0.0,
+            'appconnect_time' => 0.0,
+            'pretransfer_time' => 0.0,
+            'starttransfer_time' => 0.001,
+            'redirect_time' => 0.0,
+            'redirect_count' => 0,
+            'size_download' => strlen($this->message),
+            'size_upload' => 0,
+            'speed_download' => strlen($this->message) * 1000,
+            'speed_upload' => 0,
+            'url' => 'http://fake.local/test',
+            'primary_ip' => '127.0.0.1',
+            'content_type' => 'text/plain',
+            'redirect_url' => '',
         ]);
     }
 }

--- a/src/Response/Fake/UnauthorizedResponse.php
+++ b/src/Response/Fake/UnauthorizedResponse.php
@@ -26,9 +26,7 @@ use Override;
  */
 final readonly class UnauthorizedResponse implements Response
 {
-    public function __construct(private string $message = 'Unauthorized')
-    {
-    }
+    public function __construct(private string $message = 'Unauthorized') {}
 
     #[Override]
     public function body(): string
@@ -39,7 +37,14 @@ final readonly class UnauthorizedResponse implements Response
     #[Override]
     public function headers(): array
     {
-        return ['Content-Type' => 'text/plain'];
+        return [
+            'Content-Type' => 'text/plain; charset=utf-8',
+            'Content-Length' => (string)strlen($this->message),
+            'WWW-Authenticate' => 'Basic realm="FakeServer"',
+            'Server' => 'FakeServer/1.0',
+            'Date' => gmdate('D, d M Y H:i:s') . ' GMT',
+            'Connection' => 'close',
+        ];
     }
 
     #[Override]
@@ -47,6 +52,22 @@ final readonly class UnauthorizedResponse implements Response
     {
         return new CurlInfo([
             'http_code' => 401,
+            'total_time' => 0.001,
+            'namelookup_time' => 0.0,
+            'connect_time' => 0.0,
+            'appconnect_time' => 0.0,
+            'pretransfer_time' => 0.0,
+            'starttransfer_time' => 0.001,
+            'redirect_time' => 0.0,
+            'redirect_count' => 0,
+            'size_download' => strlen($this->message),
+            'size_upload' => 0,
+            'speed_download' => strlen($this->message) * 1000,
+            'speed_upload' => 0,
+            'url' => 'http://fake.local/unauthorized',
+            'primary_ip' => '127.0.0.1',
+            'content_type' => 'text/plain; charset=utf-8',
+            'redirect_url' => '',
         ]);
     }
 }


### PR DESCRIPTION
Adds the required headers and info fields across all fake Response classes. Includes updates to: ClientErrorResponse, NotFoundResponse, RedirectResponse, ServerErrorResponse, SuccessResponse, UnauthorizedResponse.